### PR TITLE
Fix tiles load errors for 3DStreet repo

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,13 @@ AFRAME.registerComponent('loader-3dtiles', {
 
     this.viewportSize = new Vector2(sceneEl.clientWidth, sceneEl.clientHeight);
     window.addEventListener('resize', this.onWindowResize.bind(this));
+
+    if (AFRAME.INSPECTOR && AFRAME.INSPECTOR.opened) {
+      // set active inspector camera
+      this.camera = AFRAME.INSPECTOR.camera;
+      // emit play event to start load tiles in aframe-inspector
+      this.play();
+    }
   },
   onWindowResize: function () {
     const sceneEl = this.el.sceneEl;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { Loader3DTiles, PointCloudColoring } from 'three-loader-3dtiles';
+import { Loader3DTiles, PointCloudColoring } from './dist/three-loader-3dtiles';
 import './textarea';
 import { Vector2, Vector3 } from 'three';
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ AFRAME.registerComponent('loader-3dtiles', {
     if (!this.camera) {
       throw new Error('3D Tiles: Please add an active camera or specify the target camera via the cameraEl property');
     }
+    
+    this.viewportSize = new Vector2(sceneEl.clientWidth, sceneEl.clientHeight);
 
     const { model, runtime } = await this._initTileset();
 
@@ -105,7 +107,6 @@ AFRAME.registerComponent('loader-3dtiles', {
     this.runtime = runtime;
     this.runtime.setElevationRange(data.pointcloudElevationRange.map(n => Number(n)));
 
-    this.viewportSize = new Vector2(sceneEl.clientWidth, sceneEl.clientHeight);
     window.addEventListener('resize', this.onWindowResize.bind(this));
 
     if (AFRAME.INSPECTOR && AFRAME.INSPECTOR.opened) {
@@ -163,7 +164,7 @@ AFRAME.registerComponent('loader-3dtiles', {
     }
   },
   tick: function (t, dt) {
-    if (this.runtime && this.viewportSize) {
+    if (this.runtime) {
       this.runtime.update(dt, this.viewportSize, this.camera);
       if (this.stats) {
         const worldPos = new Vector3();

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ AFRAME.registerComponent('loader-3dtiles', {
     }
   },
   tick: function (t, dt) {
-    if (this.runtime) {
+    if (this.runtime && this.viewportSize) {
       this.runtime.update(dt, this.viewportSize, this.camera);
       if (this.stats) {
         const worldPos = new Vector3();


### PR DESCRIPTION
added:
- emit play event for 3dtiles element in Editor,
- check for values of `this.viewportSize` in tick method to prevent error with `undefined` value described in this issue: https://github.com/3DStreet/3dstreet/issues/633
Also same issue: https://github.com/3DStreet/3dstreet/issues/661